### PR TITLE
Fixed internal links bug

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -439,7 +439,7 @@ class syntax_plugin_dwmenu extends DokuWiki_Syntax_Plugin {
         $link['url']  = wl($args[0]);
         list($id,$hash) = explode('#',$args[0],2);
         if (!empty($hash)) $hash = sectionID($hash, $check);
-        if ($hash) $link['url'] .= '#'.$hash;    //keep hash anchor
+        if ($hash) $link['url'] = wl($id).'#'.$hash;    //keep hash anchor
 
         $link['target'] = $conf['target']['wiki'];
         $link['class'] = $exists ? 'wikilink1' : 'wikilink2';


### PR DESCRIPTION
In the current version, when you have an internal link, you get an url such as
http://dokuwiki/doku.php?id=page#internal#internal
because of the 
```PHP
$link['url'] = wl($args[0]).'#'.$hash
```
 instead of 
```PHP
$link['url'] = wl($id).'#'.$hash
```