### PR TITLE
Fix broken div carcase (close tag)

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -338,6 +338,7 @@ class syntax_plugin_dwmenu extends DokuWiki_Syntax_Plugin {
         }
         $renderer->doc .= '</div>'."\n";
       }
+	  $renderer->doc .= '</div>'."\n";
       if($data['align'] == 'left' || $data['align'] == 'right'){
         $renderer->doc .= '<p style="clear:both;" />';
       }


### PR DESCRIPTION
Fix close tag lost for general div.dwmenu container. Also look here: https://github.com/Progi1984/dokuwiki-dwmenu/issues/10 
